### PR TITLE
hotfix/delete-web3-undefined-method deleted web3 connection

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -469,8 +469,6 @@ export default {
   async mounted() {
     this.GetLocation();
     this.localUserData = JSON.parse(JSON.stringify(this.userData));
-
-    await this.$store.dispatch('web3/connectMetamask');
   },
   methods: {
     toRoute(path) {


### PR DESCRIPTION
Удалил метод web3Connection, который не существует в текущей версии ветки 