### PR TITLE
update/34748/validators-additional-info sign-in loader fix

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -783,7 +783,7 @@
     "searchValidator": "Search validator or candidate",
     "searchCandidates": "Search proposal",
     "undelegateAfterDays": "Your tokens will be undelegate after {n} days",
-    "jailed": "jailed",
+    "jailed": "Jailed",
     "balanceLessPossible": "Balance ({balance} {s}) is less than the minimum possible to delegate: {min} {s}",
     "balanceLessPossibleUndelegate": "Balance ({balance} {s}) is less than the minimum possible to undelegate: {min} {s}",
     "delegatedAmount": "Delegated amount",

--- a/pages/sign-in.vue
+++ b/pages/sign-in.vue
@@ -311,8 +311,8 @@ export default {
         ...this.model,
         isRememberMeSelected: this.isRememberMeSelected,
       });
-      this.SetLoader(false);
       if (!res.ok) {
+        this.SetLoader(false);
         this.ShowToast(this.$t('signIn.enterEmail'));
         return;
       }
@@ -320,6 +320,7 @@ export default {
       this.userStatus = userStatus;
       this.userWalletAddress = address ? address.toLowerCase() : '';
       if (totpIsActive) {
+        this.SetLoader(false);
         await this.ShowModal({
           key: modals.securityCheck,
           actionMethod: async () => await this.nextStepAction(),

--- a/pages/validators/_id/index.vue
+++ b/pages/validators/_id/index.vue
@@ -141,7 +141,7 @@ import modals from '~/store/modals/modals';
 import { error, success } from '~/utils/success-error';
 import { CreateSignedTxForValidator, getAddressFromConsensusPub, getStyledAmount } from '~/utils/wallet';
 import {
-  GateGasPrice, ValidatorsMethods, ValidatorsGasLimit, ValidatorStatuses, OverLimitForTx,
+  GateGasPrice, ValidatorsMethods, ValidatorsGasLimit, ValidatorStatuses, OverLimitForTx, ValidatorStatusByStatuses,
 } from '~/utils/constants/validators';
 
 export default {
@@ -184,9 +184,10 @@ export default {
         { name: this.$t('validator.fee'), desc: `${Math.ceil(this.validatorData?.commission?.commission_rates?.rate * 100)}%` },
         { name: this.$t('validator.missedBlocks'), desc: this.missedBlocks },
         { name: this.$t('validator.active'), desc: this.disabledDelegate ? this.$t('proposal.no') : this.$t('proposal.yes') },
+        { name: this.$t('validators.table.status'), desc: ValidatorStatusByStatuses[this.validatorData?.status] },
       ];
       if (this.validatorData?.jailed) {
-        res.push({ name: this.$t('validators.table.status'), desc: this.$t('validators.jailed') });
+        res.push({ name: this.$t('validators.jailed'), desc: this.$t('proposal.yes') });
       }
       return res;
     },

--- a/pages/validators/_id/index.vue
+++ b/pages/validators/_id/index.vue
@@ -133,13 +133,11 @@
 <script>
 import { mapGetters } from 'vuex';
 import BigNumber from 'bignumber.js';
-import converter from 'bech32-converting';
 import {
-  DelegateMode, ExplorerUrl, TokenSymbols,
+  DelegateMode, TokenSymbols,
 } from '~/utils/enums';
 import modals from '~/store/modals/modals';
-import { error, success } from '~/utils/success-error';
-import { CreateSignedTxForValidator, getAddressFromConsensusPub, getStyledAmount } from '~/utils/wallet';
+import { CreateSignedTxForValidator, getStyledAmount } from '~/utils/wallet';
 import {
   GateGasPrice, ValidatorsMethods, ValidatorsGasLimit, ValidatorStatuses, OverLimitForTx, ValidatorStatusByStatuses,
 } from '~/utils/constants/validators';
@@ -328,6 +326,13 @@ export default {
         this.validatorData.operator_address,
         new BigNumber(this.validatorData?.min_self_delegation || 1).shiftedBy(18).toString(),
       );
+      if (!possibleTx.ok) {
+        if (possibleTx.code === 10404) {
+          this.ShowToast(this.$t('errors.notEnoughBalance'));
+        }
+        this.SetLoader(false);
+        return;
+      }
       const simulateFeeRes = await this.$store.dispatch('validators/simulate', { signedTxBytes: possibleTx.result });
       this.SetLoader(false);
 

--- a/utils/constants/validators.js
+++ b/utils/constants/validators.js
@@ -19,6 +19,12 @@ export const ValidatorStatuses = {
   UNBONDING: 'BOND_STATUS_UNBONDING', // не активный (в процессе отключения по желанию или сокращению), не генерирует блоки и не получает награды. по истечению unbondingTime токены будут возвращены юзерам
 };
 
+export const ValidatorStatusByStatuses = {
+  [ValidatorStatuses.BONDED]: 'BONDED',
+  [ValidatorStatuses.UNBONDED]: 'UNBONDED',
+  [ValidatorStatuses.UNBONDING]: 'UNBONDING',
+};
+
 // % to gas_limit
 export const OverLimitForTx = {
   develop: 1.01,

--- a/utils/wallet.js
+++ b/utils/wallet.js
@@ -402,6 +402,10 @@ export const CreateSignedTxForValidator = async (method, validatorAddress, amoun
   try {
     const address = converter('wq').toBech32(wallet.address);
     const data = await fetchCosmosAccount(address);
+    if (!data?.account?.base_account) {
+      // Account w/o any tx
+      return error(10404, 'Empty cosmos account');
+    }
     const { v1beta1 } = message.cosmos.tx;
     const { privKey, pubKeyAny } = await getPrivAndPublic(wallet.mnemonic);
     // txBody


### PR DESCRIPTION
- fixed error with empty cosmos account
- added validator status to validator _id page
- fixed loader on sign-in page